### PR TITLE
deps: bump lib to v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.0 (2024-11-08)
+
+- Upgrade lib to version v0.6.0
+
 ## v0.5.1 (2024-10-21)
 
 - Upgrade lib to version v0.5.1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # C library source
 LIB_URL = https://github.com/bitcoin-core/secp256k1
-COMMIT_HASH = v0.5.1
+COMMIT_HASH = v0.6.0
 
 # directories
 TARGET_DIR := ./priv

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Secp256k1.MixProject do
   use Mix.Project
 
-  @version "0.5.1"
+  @version "0.6.0"
 
   def project do
     [


### PR DESCRIPTION
New libsecp version was [released](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.6.0).

Tested by deleting generated files from `priv/*` and `c_src/secp256k1` , recompiling the elixir app with the new libsecp, and running functions from the API. This doesn't implement any of the Musig functions. 

lmk if I missed anything, and thanks for the implementation!